### PR TITLE
Fix: Resolve interactive hang on MinTTY and improve input source logic

### DIFF
--- a/led.h
+++ b/led.h
@@ -717,6 +717,7 @@ typedef struct {
         bool file_out_unchanged;
         bool file_out_extn;
         bool exec;
+        bool had_cmd_line_files;
         led_str_t file_out_ext;
         led_str_t file_out_dir;
         led_str_t file_out_path;


### PR DESCRIPTION
Fix https://github.com/orouits/led/issues/9

### **PR Description:**

Hello,

### The Problems

There are two distinct but related issues when running `led` with the `-f` flag in a MinTTY terminal (like Git Bash on Windows, Cygwin or Msys2).

**Scenario 1: The Hang with a Command-Line File** 
When running `led` with an explicit filename (e.g., `led -f my_file.txt`) within a MinTTY terminal, the program successfully processes the file but then **hangs** instead of exiting. This is due to an incorrect detection of `stdin` as a pipe, caused by differences in how MinTTY's pseudo-terminal environment reports itself via the `isatty()` function.

**Scenario 2: Error on Empty Input in Interactive Mode** 
When running `led -f` with no filename arguments, the program correctly waits for the user to enter filenames. However, if the user writes a file name and presses `Enter`, the original code `fopen()` the file successfully, then immediately failing with a `[ERROR] File not found:` message instead of terminating gracefully as expected.

### The Solution

This PR introduces a more robust, two-part logical fix that correctly handles these use cases and ensures consistent behavior across all terminal environments.

1. **Tracking the Input Source:** A new boolean flag, `had_cmd_line_files`, is added. This flag is set to `true` during argument parsing _only if_ filenames are explicitly provided on the command line. This prevents the program from trying to read from `stdin` after processing command-line files, which solves the main hang issue (Scenario 1).
    
2. **Handling Empty `stdin` Input:** The block of code responsible for reading filenames from `stdin` has been improved. It now checks if the line received from `fgets` is empty _after_ trimming. If the line is empty, the program correctly interprets this as the end of input and stops processing, preventing the `fopen` error (Scenario 2).

### How to Verify the Fix

After applying the changes in this PR:

**Test Case 1 (Scenario 1):**

1. In MinTTY, run `./led -f my_file.txt`.
    
2. **Result:** The program will now correctly process the file and **exit immediately** without hanging.
    

**Test Case 2 (Scenario 2):**

1. Run `./led -f`.
    
2. When the program waits for input, write an exiting file name then press `Enter` key.
    
3. **Result:** The program will now **exit cleanly** instead of printing a "File not found" error.
    

**Test Case 3 (Regression Test):**

1. Run `ls *.txt | ./led -f`.
    
2. **Result:** This command should continue to work correctly, confirming that genuine pipe functionality is not broken.